### PR TITLE
add latexmkrc

### DIFF
--- a/lecture/latexmkrc
+++ b/lecture/latexmkrc
@@ -1,0 +1,17 @@
+# latexmkrc to match build.py behavior and force continuation
+
+# Compile with pdflatex
+$pdf_mode = 1;
+
+# Use pdflatex with flags, and simulate -f behavior
+$pdflatex = 'pdflatex -interaction=nonstopmode -synctex=1 -file-line-error %O %S';
+
+# Force latexmk to continue even after encountering errors
+$force_mode = 1;
+
+# Clean up auxiliary files with -c
+@generated_exts = qw(aux bbl blg fdb_latexmk fls log out toc lof lot nav snm synctex.gz vrb);
+
+# Optional: specify the default target file
+$default_target = 'main.tex';
+


### PR DESCRIPTION
1. Added a latexmkrc file .This recreate aux files and main.toc hence toc show even when the program is run through vscoe play button
2. This Toc not showing issue seems to exist even in the course template setting ,in that setting when you run the program for the first time it shows the toc in pdf but if you run it again or build it again it does not show table of content.
3. the table of content now shows in every run by adding the latexmkrc file.